### PR TITLE
Added PublicTransportStop datamodel

### DIFF
--- a/PublicTransportStop/CONTRIBUTORS.md
+++ b/PublicTransportStop/CONTRIBUTORS.md
@@ -1,0 +1,11 @@
+# CONTRIBUTORS
+
+## Water Network Management data models
+
+## List of contributors
+___
+- Diez, Luis; [email](mailto:ldiez@tlmat.unican.es); [University of Cantabria](https://web.unican.es/) for the [SynchroniCity](https://synchronicity-iot.eu/) project
+- Sotres, Pablo; [email](mailto:psotres@tlmat.unican.es); [University of Cantabria](https://web.unican.es/) for the [WISE IoT](http://wise-iot.eu/en/home/) project
+- Choque, Johnny; [email](mailto:jchoque@tlmat.unican.es); [University of Cantabria](https://web.unican.es/) for the [SynchroniCity](https://synchronicity-iot.eu/) project
+- Santana, Juan Ramón; [email](mailto:jrsantana@tlmat.unican.es); [University of Cantabria](https://web.unican.es/) for the [SmartSantander](http://www.smartsantander.eu/) project
+____

--- a/PublicTransportStop/CURRENT-ADOPTERS.md
+++ b/PublicTransportStop/CURRENT-ADOPTERS.md
@@ -1,0 +1,7 @@
+# Current Adopters list of the data model PublicTransportRoute of the Subject [Subject]
+
+## list of use cases
+___
+___
+* Being listed here is voluntary. 
+* Being listed does not imply to be contributor of the data model.

--- a/PublicTransportStop/README.md
+++ b/PublicTransportStop/README.md
@@ -1,0 +1,215 @@
+# PublicTransportStop
+
+## Description
+
+Generic model for a public transport stop. It adopts some GTFS definitions, but it does not need to be linked to additional GTFS data.
+
+Link to the [specification](./doc/spec.md)
+
+## Examples
+
+### Normalized Example
+
+Normalized NGSI response 
+
+```json
+{
+  "id": "urn:ngsi-ld:PublicTransportStop:santander:busStop:463",
+  "type": "PublicTransportStop",
+  "dateModified": {
+    "type": "ISO8601",
+    "value": "2018-09-25T08:32:26.00Z"
+  },
+  "source": {
+    "type": "Text",
+    "value": "https://api.smartsantander.eu/"
+  },
+  "dataProvider": {
+    "type": "Text",
+    "value": "http://www.smartsantander.eu/"
+  },
+  "address": {
+    "type": "StructuredValue",
+    "value": {
+      "streetAddress": "C/ La Pereda 14",
+      "addressLocality": "Santander",
+      "addressRegion": "Cantabria",
+      "addressCountry": "Spain"
+    }
+  },
+  "location": {
+    "type": "geo:json",
+    "value": {
+      "type": "Point",
+      "coordinates": [-3.804648385,43.478053126]
+    }
+  },  
+  "stopCode": {
+    "type": "Text",
+    "value": "la_pereda_463"
+  },
+  "shortStopCode": {
+    "type": "Text",
+    "value": "463"
+  },
+  "name": {
+    "type": "Text",
+    "value": "La Pereda 14"
+  },
+  "wheelchairAccessible": {
+    "type": "Number",
+    "value": 0
+  },
+  "transportationType": {
+    "type": "StructuredValue",
+    "value": [3]
+  }, 
+  "refPublicTransportRoute" : {
+    "type": "StructuredValue",
+    "value": [
+      "urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N3","urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N4"
+    ]
+  },
+  "peopleCount": {
+    "type": "Number",
+    "value": 0
+  },
+  "refPeopleCountDevice": {
+    "type": "Text",
+    "value": "urn:ngsi-ld:PorpleCountDecice:santander:463"
+  },
+  "openingHoursSpecification": {
+    "type": "StructuredValue",
+    "value": [
+
+    ]
+  }
+}
+```
+
+### key-value pairs Example
+
+Sample uses simplified representation for data consumers `?options=keyValues`
+
+
+```json
+{
+  "id": "urn:ngsi-ld:PublicTransportStop:santander:busStop:463",
+  "type": "PublicTransportStop",
+  "dateModified": "2018-09-25T08:32:26.00Z",
+  "source": "https://api.smartsantander.eu/",
+  "dataProvider": "http://www.smartsantander.eu/",
+  "address": {
+    "streetAddress": "C/ La Pereda 14",
+    "addressLocality": "Santander",
+    "addressRegion": "Cantabria",
+    "addressCountry": "Spain"
+  },
+  "location": {
+    "type": "Point",
+    "coordinates": [-3.804648385,43.478053126]
+  },  
+  "stopCode": "la_pereda_463",
+  "shortStopCode": "463",
+  "name": "La Pereda 14",
+  "wheelchairAccessible": 0,
+  "transportationType": [3], 
+  "refPublicTransportRoute" : [
+    "urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N3","urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N4"
+  ],
+  "peopleCount":  0,
+  "refPeopleCountDevice": "urn:ngsi-ld:PorpleCountDecice:santander:463",
+  "openingHoursSpecification": []
+}
+```
+### LD Example
+
+Sample uses the NGSI-LD representation
+
+```json
+{
+  "@context": [
+    "https://smart-data-models.github.io/data-models/context.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+  ],
+  "id": "urn:ngsi-ld:PublicTransportStop:santander:busStop:463",
+  "type": "PublicTransportStop",
+  "dateModified": "2018-09-25T08:32:26.00Z",
+  "source": "https://api.smartsantander.eu/",
+  "dataProvider": "http://www.smartsantander.eu/",
+  "entityVersion": 2.0,
+  "address": {
+    "type": "Property",
+    "value": {
+      "streetAddress": "C/ La Pereda 14",
+      "addressLocality": "Santander",
+      "addressRegion": "Cantabria",
+      "addressCountry": "Spain"
+    }
+  },
+  "location": {
+    "type": "Property",
+    "value": {
+      "type": "Point",
+      "coordinates": [
+        -3.804648385,
+        43.478053126
+      ]
+    }
+  },
+  "stopCode": {
+    "type": "Property",
+    "value": "la_pereda_463"
+  },
+  "shortStopCode": {
+    "type": "Property",
+    "value": "463"
+  },
+  "name": {
+    "type": "Property",
+    "value": "La Pereda 14"
+  },
+  "wheelchairAccessible": {
+    "type": "Property",
+    "value": 0
+  },
+  "transportationType": {
+    "type": "Property",
+    "value": [
+      3
+    ]
+  },
+  "refPublicTransportRoute": {
+    "type": "Relationship",
+    "value": [
+      "urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N3",
+      "urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N4"
+    ]
+  },
+  "peopleCount": {
+    "type": "Property",
+    "value": 0
+  },
+  "refPeopleCountDevice": {
+    "type": "Property",
+    "value": "urn:ngsi-ld:PorpleCountDecice:santander:463"
+  },
+  "openingHoursSpecification": {
+    "type": "Property",
+    "value": [
+      {
+        "opens": "00:01",
+        "closes": "23:59",
+        "dayOfWeek": [
+          "Friday",
+          "Monday",
+          "Thursday",
+          "Tuesday",
+          "Wednesday"
+        ]
+      }
+    ]
+  }
+}
+```
+## Open issues

--- a/PublicTransportStop/doc/spec.md
+++ b/PublicTransportStop/doc/spec.md
@@ -1,0 +1,117 @@
+PublicTransportRoute
+  - required
+    - oneOf:
+      - address
+      - location
+    - name
+    - transportationType
+  - type: "object"  
+   - allOf:
+      - $ref: "https://raw.githubusercontent.com/smart-data-models/data-models/master/common-schema.yaml#Common"
+
+  - description :>
+    ## Description
+    Generic model for a public transport stop. It adopts some GTFS definitions, but it does not need to be linked to additional GTFS data.
+
+    ## Data Model
+  - properties:
+    - source 
+      - x-ngsi:
+        - type: "Property"
+        - model: "https://schema.org/URL"
+      - type: "string"
+      - format: "uri"
+      - description: Specifies the URL to the source of this data (either organization or where relevant more specific source)
+
+    - dataProvider: 
+      - x-ngsi:
+        - type: "Property"
+        - model: "https://schema.org/URL"
+      - type: "string"
+      - format: "URL"
+      - description: Specifies the URL to information about the provider of this information
+
+    - address:
+      - x-ngsi:
+        - type: "Property"
+        - model: "https://schema.org/address"
+      - $ref: "https://raw.githubusercontent.com/smart-data-models/data-models/master/common-schema.yaml#Address"
+
+    - location: 
+      - x-ngsi:
+        - type: "Property"
+        - model: "https://tools.ietf.org/html/rfc7946"
+      - $ref: "https://raw.githubusercontent.com/smart-data-models/data-models/master/common-schema.yaml#Geometry" 
+
+    - stopCode: 
+      - x-ngsi:
+        - type: "Property"
+        - model: "https://schema.org/Text"
+      - type: "string"  
+      - description: Identifier/code of the public transport stop.
+
+    - shortStopCode: 
+      - x-ngsi: 
+        - type: "Property"
+        - model: "https://schema.org/Text"
+      - type: "string  
+      - description: Shorter form of the identifier/code of the public transport stop.
+
+    - name: 
+      - x-ngsi:
+        - type: "Property"
+        - model: "https://schema.org/Text"
+      - type: "string"  
+      - description: The name of the public transport stop.
+
+    - wheelchairAccessible: 
+      - x-ngsi:
+        - type: "Property"
+        - model: "https://developers.google.com/transit/gtfs/reference/#stopstxt"
+      - type: "integer"
+      - minimum: 0
+      - maximum: 2
+      - description: Indicate whether or not this stop is accessible for wheelchairs. Used values are: 0-no information; 1-some vehicles of this stop allow wheelchair; 2-no vehicle of this stop allow wheelchair 
+
+    - transportationType: 
+      - x-ngsi: 
+        - type: "Property"
+        - model: "https://schema.org/Number"
+      - type: "integer"  
+      - minimum: 0
+      - maximum: 7
+      - required: true
+      - description: Types of public transport using this stop as defined in (https://developers.google.com/transit/gtfs/reference/#routestxt). 
+
+    - refPublicTransportRoute: 
+      - x-ngsi:
+        - type: "Property"
+      - type: "array"  
+        - items: 
+          - type: "string"
+          - format: "uri"
+      - description: Public transport routes using this stop.
+
+    - peopleCount: 
+      - x-ngsi: 
+        - type: "Property"
+        - model: https://schema.org/Number
+      - type: "integer"
+      - minimum: 0  
+      - description: Estimation of people waiting in the stop.
+
+    - refPeopleCountDevice: 
+      - x-ngsi: 
+        - type: "Property"
+      - type: "string"
+      - format: "uri"  
+      - description: Reference to the [Device](https://github.com/Fiware/dataModels/blob/master/specs/Device/Device/doc/spec.md) providing people count estimate.
+
+    - openingHoursSpecification: 
+      - x-ngsi: 
+        - type: "Property"
+        - model: "http://schema.org/openingHoursSpecification"
+      - type: "array"
+      - items:
+        - $ref: ""
+      - description: Opening hours of this stop.

--- a/PublicTransportStop/example-normalized.json
+++ b/PublicTransportStop/example-normalized.json
@@ -1,0 +1,46 @@
+{
+  "id": "urn:ngsi-ld:PublicTransportStop:santander:busStop:463",
+  "type": "PublicTransportStop",
+  "dateModified": "2018-09-25T08:32:26.00Z",
+  "source": "https://api.smartsantander.eu/",
+  "dataProvider": "http://www.smartsantander.eu/",
+  "address": {
+    "streetAddress": "C/ La Pereda 14",
+    "addressLocality": "Santander",
+    "addressRegion": "Cantabria",
+    "addressCountry": "Spain"
+  },
+  "location": {
+    "type": "Point",
+    "coordinates": [
+      -3.804648385,
+      43.478053126
+    ]
+  },
+  "stopCode": "la_pereda_463",
+  "shortStopCode": "463",
+  "name": "La Pereda 14",
+  "wheelchairAccessible": 0,
+  "transportationType": [
+    3
+  ],
+  "refPublicTransportRoute": [
+    "urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N3",
+    "urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N4"
+  ],
+  "peopleCount": 0,
+  "refPeopleCountDevice": "urn:ngsi-ld:PorpleCountDecice:santander:463",
+  "openingHoursSpecification": [
+    {
+      "opens": "00:01",
+      "closes": "23:59",
+      "dayOfWeek": [
+        "Friday",
+        "Monday",
+        "Thursday",
+        "Tuesday",
+        "Wednesday"
+      ]
+    }
+  ]
+}

--- a/PublicTransportStop/example.json
+++ b/PublicTransportStop/example.json
@@ -1,0 +1,88 @@
+{
+  "id": "urn:ngsi-ld:PublicTransportStop:santander:busStop:463",
+  "type": "PublicTransportStop",
+  "dateModified": {
+    "type": "ISO8601",
+    "value": "2018-09-25T08:32:26.00Z"
+  },
+  "source": {
+    "type": "Text",
+    "value": "https://api.smartsantander.eu/"
+  },
+  "dataProvider": {
+    "type": "Text",
+    "value": "http://www.smartsantander.eu/"
+  },
+  "address": {
+    "type": "StructuredValue",
+    "value": {
+      "streetAddress": "C/ La Pereda 14",
+      "addressLocality": "Santander",
+      "addressRegion": "Cantabria",
+      "addressCountry": "Spain"
+    }
+  },
+  "location": {
+    "type": "geo:json",
+    "value": {
+      "type": "Point",
+      "coordinates": [
+        -3.804648385,
+        43.478053126
+      ]
+    }
+  },
+  "stopCode": {
+    "type": "Text",
+    "value": "la_pereda_463"
+  },
+  "shortStopCode": {
+    "type": "Text",
+    "value": "463"
+  },
+  "name": {
+    "type": "Text",
+    "value": "La Pereda 14"
+  },
+  "wheelchairAccessible": {
+    "type": "Number",
+    "value": 0
+  },
+  "transportationType": {
+    "type": "StructuredValue",
+    "value": [
+      3
+    ]
+  },
+  "refPublicTransportRoute": {
+    "type": "StructuredValue",
+    "value": [
+      "urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N3",
+      "urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N4"
+    ]
+  },
+  "peopleCount": {
+    "type": "Number",
+    "value": 0
+  },
+  "refPeopleCountDevice": {
+    "type": "Text",
+    "value": "urn:ngsi-ld:PorpleCountDecice:santander:463"
+  },
+  "openingHoursSpecification": {
+    "type": "StructuredValue",
+    "value": [
+      {
+        "opens": "00:01",
+        "closes": "23:59",
+        "dayOfWeek": [
+          "Friday",
+          "Monday",
+          "Thursday",
+          "Tuesday",
+          "Wednesday"
+        ]
+      }
+    ]
+  }
+}

--- a/PublicTransportStop/example.jsonld
+++ b/PublicTransportStop/example.jsonld
@@ -1,0 +1,84 @@
+{
+  "@context": [
+    "https://smart-data-models.github.io/data-models/context.jsonld",
+    "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+  ],
+  "id": "urn:ngsi-ld:PublicTransportStop:santander:busStop:463",
+  "type": "PublicTransportStop",
+  "dateModified": "2018-09-25T08:32:26.00Z",
+  "source": "https://api.smartsantander.eu/",
+  "dataProvider": "http://www.smartsantander.eu/",
+  "entityVersion": 2.0,
+  "address": {
+    "type": "Property",
+    "value": {
+      "streetAddress": "C/ La Pereda 14",
+      "addressLocality": "Santander",
+      "addressRegion": "Cantabria",
+      "addressCountry": "Spain"
+    }
+  },
+  "location": {
+    "type": "Property",
+    "value": {
+      "type": "Point",
+      "coordinates": [
+        -3.804648385,
+        43.478053126
+      ]
+    }
+  },
+  "stopCode": {
+    "type": "Property",
+    "value": "la_pereda_463"
+  },
+  "shortStopCode": {
+    "type": "Property",
+    "value": "463"
+  },
+  "name": {
+    "type": "Property",
+    "value": "La Pereda 14"
+  },
+  "wheelchairAccessible": {
+    "type": "Property",
+    "value": 0
+  },
+  "transportationType": {
+    "type": "Property",
+    "value": [
+      3
+    ]
+  },
+  "refPublicTransportRoute": {
+    "type": "Relationship",
+    "value": [
+      "urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N3",
+      "urn:ngsi-ld:PublicTransportRoute:santander:transport:busLine:N4"
+    ]
+  },
+  "peopleCount": {
+    "type": "Property",
+    "value": 0
+  },
+  "refPeopleCountDevice": {
+    "type": "Property",
+    "value": "urn:ngsi-ld:PorpleCountDecice:santander:463"
+  },
+  "openingHoursSpecification": {
+    "type": "Property",
+    "value": [
+      {
+        "opens": "00:01",
+        "closes": "23:59",
+        "dayOfWeek": [
+          "Friday",
+          "Monday",
+          "Thursday",
+          "Tuesday",
+          "Wednesday"
+        ]
+      }
+    ]
+  }
+}

--- a/PublicTransportStop/schema.json
+++ b/PublicTransportStop/schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$schemaVersion": "0.0",
+  "$id": "https://smart-data-models.github.io/dataModel.UrbanMobility/PublicTransportStop/schema.json",
+  "title": "Urban mobility PublicTransportStop schema",
+  "description": "A generic public transport stop",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/GSMA-Commons"
+    },
+    {
+      "$ref": "https://smart-data-models.github.io/data-models/common-schema.json#/definitions/Location-Commons"
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "PublicTransportStop"
+          ],
+          "description": "NGSI Entity type"
+        },
+        "stopCode": {
+          "type": "string"
+        },
+        "shortStopCode": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "wheelchairAccessible": {
+          "type": "integer",
+          "enum": [
+            0,
+            1,
+            2
+          ]
+        },
+        "transportationType": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "enum": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7
+            ]
+          }
+        },
+        "refPublicTransportRoute": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "peopleCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "refPeopleCountDevice": {
+          "type": "string",
+          "format": "uri"
+        },
+        "openingHoursSpecification": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "opens": {
+                "type": "string",
+                "pattern": "[0-9]{2}:[0-9]{2}"
+              },
+              "closes": {
+                "type": "string",
+                "pattern": "[0-9]{2}:[0-9]{2}"
+              },
+              "dayOfWeek": {
+                "type": "string",
+                "enum": [
+                  "Friday",
+                  "Monday",
+                  "PublicHolidays",
+                  "Saturday",
+                  "Sunday",
+                  "Thursday",
+                  "Tuesday",
+                  "Wednesday"
+                ]
+              }
+            }
+          },
+          "minItems": 1
+        }
+      }
+    }
+  ],
+  "required": [
+    "id",
+    "type",
+    "transportationType",
+    "name"
+  ],
+  "anyOf": [
+    {
+      "required": [
+        "location"
+      ]
+    },
+    {
+      "required": [
+        "address"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Generic model for a public transport stop. It adopts some GTFS definitions, but it does not need to be linked to additional GTFS data.
